### PR TITLE
Small fix for theme toggling.

### DIFF
--- a/app/(landing)/components/elements/comments.tsx
+++ b/app/(landing)/components/elements/comments.tsx
@@ -9,8 +9,8 @@ import {
 import { useTheme } from "next-themes";
 
 export default function Comments() {
-  const { theme } = useTheme();
-  const giscusTheme = theme === "dark" ? "transparent_dark" : "light";
+  const { resolvedTheme } = useTheme();
+  const giscusTheme = resolvedTheme === "dark" ? "transparent_dark" : "light";
   return (
     <Giscus
       repo={giscusRepo}

--- a/components/utils/theme-toggler.tsx
+++ b/components/utils/theme-toggler.tsx
@@ -2,8 +2,9 @@
 
 import * as React from "react";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef } from "react";
 import { flushSync } from "react-dom";
+import { useTheme } from "next-themes";
 
 import { cn } from "@/lib/utils";
 import { MoonIcon, SunIcon } from "@phosphor-icons/react";
@@ -17,34 +18,17 @@ export const AnimatedThemeToggler = ({
   duration = 400,
   ...props
 }: AnimatedThemeTogglerProps) => {
-  const [isDark, setIsDark] = useState(false);
+  const { resolvedTheme, setTheme } = useTheme();
   const buttonRef = useRef<HTMLButtonElement>(null);
-
-  useEffect(() => {
-    const updateTheme = () => {
-      setIsDark(document.documentElement.classList.contains("dark"));
-    };
-
-    updateTheme();
-
-    const observer = new MutationObserver(updateTheme);
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["class"],
-    });
-
-    return () => observer.disconnect();
-  }, []);
+  const isDark = resolvedTheme === "dark";
 
   const toggleTheme = useCallback(async () => {
     if (!buttonRef.current) return;
 
     await document.startViewTransition(() => {
       flushSync(() => {
-        const newTheme = !isDark;
-        setIsDark(newTheme);
-        document.documentElement.classList.toggle("dark");
-        localStorage.setItem("theme", newTheme ? "dark" : "light");
+        const newTheme = isDark ? "light" : "dark";
+        setTheme(newTheme);
       });
     }).ready;
 
@@ -57,7 +41,7 @@ export const AnimatedThemeToggler = ({
       Math.max(top, window.innerHeight - top),
     );
 
-    const animation = document.documentElement.animate(
+    document.documentElement.animate(
       {
         clipPath: [
           `circle(0px at ${x}px ${y}px)`,
@@ -70,10 +54,7 @@ export const AnimatedThemeToggler = ({
         pseudoElement: "::view-transition-new(root)",
       },
     );
-    animation.onfinish = () => {
-      window.location.reload();
-    };
-  }, [isDark, duration]);
+  }, [isDark, duration, setTheme]);
   return (
     <button
       ref={buttonRef}


### PR DESCRIPTION
This pull request refactors theme handling in the comments and theme toggler components to use the `resolvedTheme` and `setTheme` API from `next-themes`, resulting in more reliable and simplified theme switching. The changes remove manual DOM manipulation and state management in favor of the official theme context.

**Theme Handling Improvements:**

* Replaced usage of the `theme` property with `resolvedTheme` from `useTheme` in both `comments.tsx` and `theme-toggler.tsx` for more accurate theme detection, especially with system themes. [[1]](diffhunk://#diff-dea5fd645155fa53b8ee67c00cd9bca7015e0c4fd11980ada9f067abbf484b0bL12-R13) [[2]](diffhunk://#diff-b3bdc5adcb6934fe506d074409eeba1947bd1e4bbfb9615a3b031cf762175aa1L20-R31)
* Switched theme toggling logic to use the `setTheme` function from `next-themes` instead of manually toggling the `dark` class and updating `localStorage`.

**Code Simplification and Cleanup:**

* Removed unnecessary `useState`, `useEffect`, and `MutationObserver` logic for tracking theme changes in `theme-toggler.tsx`, relying solely on `useTheme`.
* Cleaned up unused imports (`useEffect`, `useState`) from `theme-toggler.tsx` since theme state is now handled by `next-themes`.

**Other Minor Changes:**

* Removed forced page reload after theme animation, as theme changes are now handled reactively.